### PR TITLE
Fix Postman converter header removal

### DIFF
--- a/packages/spec/src/lib/loaders/postman/postman-converter.ts
+++ b/packages/spec/src/lib/loaders/postman/postman-converter.ts
@@ -431,7 +431,7 @@ function requestToOperation(
               );
               const [contentTypeValue] =
                 contentTypeIdx !== -1
-                  ? headers.splice(contentTypeIdx).map((h) => h.value)
+                  ? headers.splice(contentTypeIdx, 1).map((h) => h.value)
                   : [];
               const contentType = response.body
                 ? parse(contentTypeValue || 'application/json')?.type


### PR DESCRIPTION
## Summary
- ensure only the `Content-Type` header is removed when processing response headers

## Testing
- `npm test` *(fails: Cannot find package 'chalk')*

------
https://chatgpt.com/codex/tasks/task_e_68402e17a7908328878609a340b7f82f